### PR TITLE
Added api endpoints to fetch shorturl visit record

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -6,6 +6,7 @@ namespace PalPalani\BayLinks;
 
 use PalPalani\BayLinks\Resources\AccountResource;
 use PalPalani\BayLinks\Resources\CreateShortURLResource;
+use PalPalani\BayLinks\Resources\ShortUrlVisitRecordResource;
 use Saloon\Http\Connector;
 
 final class Factory extends Connector
@@ -41,5 +42,10 @@ final class Factory extends Connector
     public function createShortURL(): CreateShortURLResource
     {
         return new CreateShortURLResource($this);
+    }
+
+    public function ShortUrlVisitRecord(): ShortUrlVisitRecordResource
+    {
+        return new ShortUrlVisitRecordResource($this);
     }
 }

--- a/src/Requests/ShortURL/ShortUrlVisitRecordRequest.php
+++ b/src/Requests/ShortURL/ShortUrlVisitRecordRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace PalPalani\BayLinks\Requests\ShortURL;
+
+use PalPalani\BayLinks\Objects\Account;
+use PalPalani\BayLinks\Responses\ShortURL\ShortUrlVisitRecordResponse;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Contracts\Response;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+use Saloon\Traits\Plugins\AlwaysThrowOnErrors;
+
+final class ShortUrlVisitRecordRequest extends Request implements HasBody
+{
+    use AlwaysThrowOnErrors;
+    use HasJsonBody;
+
+    protected Method $method = Method::POST;
+
+    public function __construct(protected array $data = [])
+    {
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return '/links/short-url-payload';
+    }
+
+    public function defaultBody(): array
+    {
+        return $this->data;
+    }
+
+    public function createDtoFromResponse(Response $response): Account
+    {
+        return ShortUrlVisitRecordResponse::make($response);
+    }
+}

--- a/src/Resources/ShortUrlVisitRecordResource.php
+++ b/src/Resources/ShortUrlVisitRecordResource.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PalPalani\BayLinks\Resources;
+
+use PalPalani\BayLinks\Objects\Account;
+use PalPalani\BayLinks\Requests\ShortURL\ShortUrlVisitRecordRequest;
+
+final class ShortUrlVisitRecordResource extends Resource
+{
+    /**
+     * @return mixed|Account
+     */
+    public function post(array $data): mixed
+    {
+        return $this->connector->send(new ShortUrlVisitRecordRequest($data))->dto();
+    }
+}

--- a/src/Responses/ShortURL/ShortUrlVisitRecordResponse.php
+++ b/src/Responses/ShortURL/ShortUrlVisitRecordResponse.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PalPalani\BayLinks\Responses\ShortURL;
+
+use PalPalani\BayLinks\Objects\Account;
+use Saloon\Contracts\Response;
+
+/**
+ * @phpstan-import-type AccountData from Account
+ */
+final class ShortUrlVisitRecordResponse
+{
+    public static function make(Response $response): Account
+    {
+        /** @var AccountData $data */
+        $data = $response->json();
+
+        return new Account(...$data);
+    }
+}


### PR DESCRIPTION
Example 

    $getvisit = $bayLinks->ShortUrlVisitRecord()->post(
        [
            "from_date" => "2023-08-25 06:46:16",
            "to_date" => "2023-09-06 06:46:17",
            "url" => "/mO"
        ]
    );